### PR TITLE
Minor Fix

### DIFF
--- a/barcode/__init__.py
+++ b/barcode/__init__.py
@@ -45,7 +45,7 @@ __BARCODE_MAP = dict(
     itf=ITF,
 )
 
-PROVIDED_BARCODES = list(__BARCODE_MAP.keys())
+PROVIDED_BARCODES = list(__BARCODE_MAP)
 PROVIDED_BARCODES.sort()
 
 


### PR DESCRIPTION
There is no need to explicitly call `keys` and convert to a `list`. `list(dict)` is sufficient in this case as the iteration over the dict object yields its `keys`.

`PROVIDED_BARCODES = list(__BARCODE_MAP.keys())`