### PR TITLE
Optimise Code128 length

### DIFF
--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -179,7 +179,7 @@ class Code128(Barcode):
                     digits += 1
                 else:
                     break
-            return digits > 3
+            return digits > 3 and (digits%2) == 0
 
         codes = []
         if self._charset == 'C' and not char.isdigit():


### PR DESCRIPTION
If the number of digits is uneven, the resulting barcode will be 1 character shorter if you wait to change character set (you only need to change the character set once)