### PR TITLE
docs: Fix simple typo, complety -> completely

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -211,7 +211,7 @@ class BaseWriter:
             bxe = xpos
             # Add right quiet zone to every line, except last line,
             # quiet zone already provided with background,
-            # should it be removed complety?
+            # should it be removed completely?
             if (cc + 1) != len(code):
                 self._callbacks["paint_module"](
                     xpos, ypos, self.quiet_zone, self.background


### PR DESCRIPTION
There is a small typo in barcode/writer.py.

Should read `completely` rather than `complety`.

