### PR TITLE
Adds support for longer guard bar to EAN13 and EAN8

### DIFF
--- a/barcode/__init__.py
+++ b/barcode/__init__.py
@@ -13,8 +13,10 @@ from barcode.codex import Code39
 from barcode.codex import Gs1_128
 from barcode.codex import PZN
 from barcode.ean import EAN13
+from barcode.ean import EAN13_GUARD
 from barcode.ean import EAN14
 from barcode.ean import EAN8
+from barcode.ean import EAN8_GUARD
 from barcode.ean import JAN
 from barcode.errors import BarcodeNotFoundError
 from barcode.isxn import ISBN10
@@ -26,7 +28,9 @@ from barcode.version import version  # noqa: F401
 
 __BARCODE_MAP = {
     "ean8": EAN8,
+    "ean8-guard": EAN8_GUARD,
     "ean13": EAN13,
+    "ean13-guard": EAN13_GUARD,
     "ean": EAN13,
     "gtin": EAN14,
     "ean14": EAN14,

--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -65,6 +65,7 @@ class EuropeanArticleNumber13(Barcode):
         else:
             self.ean = "{}{}".format(ean, self.calculate_checksum())
 
+        self.guardbar = guardbar
         if guardbar:
             self.EDGE = _ean.EDGE.replace("1", "G")
             self.MIDDLE = _ean.MIDDLE.replace("1", "G")
@@ -77,6 +78,8 @@ class EuropeanArticleNumber13(Barcode):
         return self.ean
 
     def get_fullcode(self):
+        if self.guardbar:
+            return self.ean[0] + " " + self.ean[1:7] + " " + self.ean[7:] + " >"
         return self.ean
 
     def calculate_checksum(self):
@@ -179,6 +182,10 @@ class EuropeanArticleNumber8(EuropeanArticleNumber13):
         code += self.EDGE
         return [code]
 
+    def get_fullcode(self):
+        if self.guardbar:
+            return "< " + self.ean[:4] + " " + self.ean[4:] + " >"
+        return self.ean
 
 class EuropeanArticleNumber14(EuropeanArticleNumber13):
     """Represents an EAN-14 barcode. See EAN13's __init__ for details.

--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -43,7 +43,7 @@ class EuropeanArticleNumber13(Barcode):
 
     digits = 12
 
-    def __init__(self, ean, writer=None, no_checksum=False):
+    def __init__(self, ean, writer=None, no_checksum=False, guardbar=False):
         ean = ean[: self.digits]
         if not ean.isdigit():
             raise IllegalCharacterError("EAN code can only contain numbers.")
@@ -64,6 +64,13 @@ class EuropeanArticleNumber13(Barcode):
             )
         else:
             self.ean = "{}{}".format(ean, self.calculate_checksum())
+
+        if guardbar:
+            self.EDGE = _ean.EDGE.replace("1", "G")
+            self.MIDDLE = _ean.MIDDLE.replace("1", "G")
+        else:
+            self.EDGE = _ean.EDGE
+            self.MIDDLE = _ean.MIDDLE
         self.writer = writer or Barcode.default_writer()
 
     def __str__(self):
@@ -92,14 +99,14 @@ class EuropeanArticleNumber13(Barcode):
         :returns: The pattern as string
         :rtype: String
         """
-        code = _ean.EDGE[:]
+        code = self.EDGE[:]
         pattern = _ean.LEFT_PATTERN[int(self.ean[0])]
         for i, number in enumerate(self.ean[1:7]):
             code += _ean.CODES[pattern[i]][int(number)]
-        code += _ean.MIDDLE
+        code += self.MIDDLE
         for number in self.ean[7:]:
             code += _ean.CODES["C"][int(number)]
-        code += _ean.EDGE
+        code += self.EDGE
         return [code]
 
     def to_ascii(self):
@@ -109,7 +116,7 @@ class EuropeanArticleNumber13(Barcode):
         """
         code = self.build()
         for i, line in enumerate(code):
-            code[i] = line.replace("1", "|").replace("0", " ")
+            code[i] = line.replace("G", "|").replace("1", "|").replace("0", " ")
         return "\n".join(code)
 
     def render(self, writer_options=None, text=None):
@@ -154,8 +161,8 @@ class EuropeanArticleNumber8(EuropeanArticleNumber13):
 
     digits = 7
 
-    def __init__(self, ean, writer=None):
-        EuropeanArticleNumber13.__init__(self, ean, writer)
+    def __init__(self, ean, writer=None, guardbar=False):
+        EuropeanArticleNumber13.__init__(self, ean, writer, guardbar=guardbar)
 
     def build(self):
         """Builds the barcode pattern from `self.ean`.
@@ -163,13 +170,13 @@ class EuropeanArticleNumber8(EuropeanArticleNumber13):
         :returns: The pattern as string
         :rtype: String
         """
-        code = _ean.EDGE[:]
+        code = self.EDGE[:]
         for number in self.ean[:4]:
             code += _ean.CODES["A"][int(number)]
-        code += _ean.MIDDLE
+        code += self.MIDDLE
         for number in self.ean[4:]:
             code += _ean.CODES["C"][int(number)]
-        code += _ean.EDGE
+        code += self.EDGE
         return [code]
 
 

--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -128,6 +128,14 @@ class EuropeanArticleNumber13(Barcode):
         return Barcode.render(self, options, text)
 
 
+class EuropeanArticleNumber13WithGuard(EuropeanArticleNumber13):
+
+    name = "EAN-13 with guards"
+
+    def __init__(self, *args, guardbar=True, **kwargs):
+        return super().__init__(*args, guardbar=guardbar, **kwargs)
+
+
 class JapanArticleNumber(EuropeanArticleNumber13):
     """Initializes JAN barcode.
 
@@ -187,6 +195,15 @@ class EuropeanArticleNumber8(EuropeanArticleNumber13):
             return "< " + self.ean[:4] + " " + self.ean[4:] + " >"
         return self.ean
 
+
+class EuropeanArticleNumber8WithGuard(EuropeanArticleNumber8):
+
+    name = "EAN-8 with guards"
+
+    def __init__(self, *args, guardbar=True, **kwargs):
+        return super().__init__(*args, guardbar=guardbar, **kwargs)
+
+
 class EuropeanArticleNumber14(EuropeanArticleNumber13):
     """Represents an EAN-14 barcode. See EAN13's __init__ for details.
 
@@ -218,5 +235,7 @@ class EuropeanArticleNumber14(EuropeanArticleNumber13):
 # Shortcuts
 EAN14 = EuropeanArticleNumber14
 EAN13 = EuropeanArticleNumber13
+EAN13_GUARD = EuropeanArticleNumber13WithGuard
 EAN8 = EuropeanArticleNumber8
+EAN8_GUARD = EuropeanArticleNumber8WithGuard
 JAN = JapanArticleNumber

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -196,7 +196,7 @@ class BaseWriter:
                     elif line[i] == "G":
                         mlist.append((c, 1.1))
                     else:
-                        mlist.append((-c, 1))
+                        mlist.append((-c, 1.1))
                     c = 1
             # Left quiet zone is x startposition
             xpos = self.quiet_zone

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -177,6 +177,7 @@ class BaseWriter:
         if self._callbacks["initialize"] is not None:
             self._callbacks["initialize"](code)
         ypos = 1.0
+        base_height = self.module_height
         for cc, line in enumerate(code):
             """
             Pack line to list give better gfx result, otherwise in can
@@ -191,14 +192,19 @@ class BaseWriter:
                     c += 1
                 else:
                     if line[i] == "1":
-                        mlist.append(c)
+                        mlist.append((c, 1))
+                    elif line[i] == "G":
+                        mlist.append((c, 1.1))
                     else:
-                        mlist.append(-c)
+                        mlist.append((-c, 1))
                     c = 1
             # Left quiet zone is x startposition
             xpos = self.quiet_zone
             bxs = xpos  # x start of barcode
             for mod in mlist:
+                self.module_height = base_height * mod[1]
+                mod = mod[0]
+
                 if mod < 1:
                     color = self.background
                 else:

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -6,3 +6,10 @@ def test_ean8_builds():
     ean = get_barcode("ean8", "40267708")
     bc = ean.build()
     assert ref == bc[0]
+
+def test_ean8_builds_with_longer_bars():
+    ref = "G0G01000110001101001001101011110G0G01000100100010011100101001000G0G"
+    ean = get_barcode("ean8", "40267708", options={"guardbar": True})
+    bc = ean.build()
+    assert ref == bc[0]
+

--- a/tests/test_manually.py
+++ b/tests/test_manually.py
@@ -32,7 +32,9 @@ NO_PIL = "<h3>Pillow was not found. No PNG-Image created.</h3></p>\n"
 
 TESTCODES = (
     ("ean8", "40267708"),
+    ("ean8-guard", "40267708"),
     ("ean13", "5901234123457"),
+    ("ean13-guard", "5901234123457"),
     ("ean14", "12345678911230"),
     ("upca", "36000291453"),
     ("jan", "4901234567894"),

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -36,3 +36,11 @@ def test_saving_svg_to_byteio():
 
     with open(f"{TESTPATH}/somefile.svg", "wb") as f:
         EAN13("100000011111", writer=SVGWriter()).write(f)
+
+def test_saving_svg_to_byteio_with_guardbar():
+    rv = BytesIO()
+    EAN13(str(100000902922), writer=SVGWriter(), guardbar=True).write(rv)
+
+    with open(f"{TESTPATH}/somefile_guardbar.svg", "wb") as f:
+        EAN13("100000011111", writer=SVGWriter(), guardbar=True).write(f)
+


### PR DESCRIPTION
  This PR tries to partially solve Issue #11 

  Adds a parameter to both classes that controls if we want longer guard
bars and then while building the code to be generated, use "G" instead of
"1" in those places we will need to have a longer bar.

  During the write, interpret every "G" the same as "1" but add an height
factor to the mod list. To avoid changing the entire code base to add a
height parameter, set the self.module_height for every bar generated.