### PR TITLE
Remove is-even check from Code128 look_next()

### DIFF
--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -3,11 +3,8 @@
 :Provided barcodes: Code 39, Code 128, PZN
 """
 from barcode.base import Barcode
-from barcode.charsets import code128
-from barcode.charsets import code39
-from barcode.errors import BarcodeError
-from barcode.errors import IllegalCharacterError
-from barcode.errors import NumberOfDigitsError
+from barcode.charsets import code39, code128
+from barcode.errors import BarcodeError, IllegalCharacterError, NumberOfDigitsError
 
 __docformat__ = "restructuredtext en"
 
@@ -169,7 +166,7 @@ class Code128(Barcode):
                     digits += 1
                 else:
                     break
-            return digits > 3 and (digits % 2) == 0
+            return digits > 3
 
         codes = []
         if self._charset == "C" and not char.isdigit():


### PR DESCRIPTION
Okay so I'm not totally sure I understand the logic behind the is-even check here. It was added as part of a commit intended to optimise the barcode width.

So, from what I can see, there are two rules for whether to switch to 128C:
- If the 128C section is followed by another charset switch, it should be at least 5 digits long to save space.
- If it is the last charset of the barcode, it should be at least 4 digits long to save space.

As long as these two things are true, you will always see a space saving over not switching.

Now, the code only checks if it's at least 4 digits, but that's fine since it's simpler and just means that there is a case where we will switch to 128C without saving any width, but also without incurring any additional width.

Correct me if I'm wrong, but I don't think evenness comes into it - a single digit encoded in 128C does not itself save space, but may as well be included in the rest of the 128C block which we already know will save space because it's at least 4 characters long.

Because of the evenness check, there's a case where we can create a longer barcode. When the barcode starts with a sequence of 5 digits, the first digit will be encoded in 128B because of the odd number of digits, incurring an additional charset switch and widening the barcode.

I'm wondering if anyone has an example of a barcode which is shorter because of the evenness check. Otherwise I think we should go ahead and remove it as proposed.