### PR TITLE
Fix deprecation warning about ImageFont.getsize

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -438,13 +438,13 @@ else:
             font_size = int(mm2px(pt2mm(self.font_size), self.dpi))
             font = ImageFont.truetype(self.font_path, font_size)
             for subtext in self.text.split("\n"):
-                width, height = font.getsize(subtext)
-                # determine the maximum width of each line
                 pos = (
-                    mm2px(xpos, self.dpi) - width // 2,
-                    mm2px(ypos, self.dpi) - height,
+                    mm2px(xpos, self.dpi),
+                    mm2px(ypos, self.dpi),
                 )
-                self._draw.text(pos, subtext, font=font, fill=self.foreground)
+                self._draw.text(
+                    pos, subtext, font=font, fill=self.foreground, anchor="ms"
+                )
                 ypos += pt2mm(self.font_size) / 2 + self.text_line_distance
 
         def _finish(self):

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -443,7 +443,7 @@ else:
                     mm2px(ypos, self.dpi),
                 )
                 self._draw.text(
-                    pos, subtext, font=font, fill=self.foreground, anchor="ms"
+                    pos, subtext, font=font, fill=self.foreground, anchor="md"
                 )
                 ypos += pt2mm(self.font_size) / 2 + self.text_line_distance
 


### PR DESCRIPTION
python-barcode/barcode/writer.py:441: DeprecationWarning: getsize is
deprecated and will be removed in Pillow 10 (2023-07-01). Use getbbox
or getlength instead.
    width, height = font.getsize(subtext)

`ImageFont.getsize` is deprecated since the version 9.2 of Pillow. We
use anchor instead of computing the right position to have an aligned
text.

It is related to the issue #163.
The solution was suggested by @nulano (contributor of Pillow).