### PR TITLE
Fix issue #171 calculating checksum before any controls

### DIFF
--- a/barcode/isxn.py
+++ b/barcode/isxn.py
@@ -72,7 +72,6 @@ class InternationalStandardBookNumber10(InternationalStandardBookNumber13):
         super().__init__("978" + isbn, writer)
         self.isbn10 = isbn
         self.isbn10 = f"{isbn}{self._calculate_checksum()}"
-        
 
     def _calculate_checksum(self):
         tmp = sum(x * int(y) for x, y in enumerate(self.isbn10[:9], start=1)) % 11

--- a/barcode/isxn.py
+++ b/barcode/isxn.py
@@ -69,9 +69,10 @@ class InternationalStandardBookNumber10(InternationalStandardBookNumber13):
     def __init__(self, isbn, writer=None):
         isbn = isbn.replace("-", "")
         isbn = isbn[: self.digits]
+        super().__init__("978" + isbn, writer)
         self.isbn10 = isbn
         self.isbn10 = f"{isbn}{self._calculate_checksum()}"
-        super().__init__("978" + isbn, writer)
+        
 
     def _calculate_checksum(self):
         tmp = sum(x * int(y) for x, y in enumerate(self.isbn10[:9], start=1)) % 11


### PR DESCRIPTION
Moved `super().__init__` before calling `_calculate_checksum()` to check if the string contains any letters to prevent value errors that can happen when calculating checksum. I tested the new version with the input `0132354187` and the produced barcode before and after the commit is the same  as `9780132352`.