### PR TITLE
fix wrong bar width in ImageWriter

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -101,6 +101,8 @@ class BaseWriter:
         self.text_line_distance = 1
         self.center_text = True
         self.guard_height_factor = 1.1
+        self.margin_top = 1
+        self.margin_bottom = 1
 
     def calculate_size(self, modules_per_line, number_of_lines):
         """Calculates the size of the barcode in pixel.
@@ -115,7 +117,7 @@ class BaseWriter:
         :rtype: Tuple
         """
         width = 2 * self.quiet_zone + modules_per_line * self.module_width
-        height = 2.0 + self.module_height * number_of_lines
+        height = self.margin_bottom + self.margin_top + self.module_height * number_of_lines
         number_of_text_lines = len(self.text.splitlines())
         if self.font_size and self.text:
             height += (
@@ -204,7 +206,7 @@ class BaseWriter:
         """
         if self._callbacks["initialize"] is not None:
             self._callbacks["initialize"](code)
-        ypos = 1.0
+        ypos = self.margin_top
         base_height = self.module_height
         for cc, line in enumerate(code):
             # Left quiet zone is x startposition

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -428,7 +428,7 @@ else:
             size = [
                 (mm2px(xpos, self.dpi), mm2px(ypos, self.dpi)),
                 (
-                    mm2px(xpos + width, self.dpi),
+                    mm2px(xpos + width, self.dpi) - 1,
                     mm2px(ypos + self.module_height, self.dpi),
                 ),
             ]

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -117,7 +117,9 @@ class BaseWriter:
         :rtype: Tuple
         """
         width = 2 * self.quiet_zone + modules_per_line * self.module_width
-        height = self.margin_bottom + self.margin_top + self.module_height * number_of_lines
+        height = (
+            self.margin_bottom + self.margin_top + self.module_height * number_of_lines
+        )
         number_of_text_lines = len(self.text.splitlines())
         if self.font_size and self.text:
             height += (


### PR DESCRIPTION
fixes #79 and maybe others?

This might seem trivial, but took me a couple of minutes to track it down. I'm attaching false-colored images for reference. Please pay attention to the final white bar in particular.
SvgWriter is not affected as the rectangle implementation is different.

# DPI 300

before
![before](https://user-images.githubusercontent.com/20643301/203861647-947506f5-068b-4df7-b7b0-b820b0544e4c.png)

after
![after](https://user-images.githubusercontent.com/20643301/203861654-f1e9bc1c-524f-4f6c-87cd-8d65e53e2d65.png)

# DPI 100

before
<img src="https://user-images.githubusercontent.com/20643301/203866170-7b386d2e-2c6a-4476-ae73-54c913e9968e.png" width="400">

after
<img src="https://user-images.githubusercontent.com/20643301/203866187-3832700a-fb2f-4e9f-8a58-6de53a65ad2c.png" width="400">
