### PR TITLE
Implement PZN8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,6 @@ repos:
     -   id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.990'
+    rev: 'v0.991'
     hooks:
     -   id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,11 @@ repos:
           - flake8-comprehensions
           - flake8-bugbear
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.2.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: 'v0.990'
     hooks:
     -   id: mypy

--- a/barcode/__init__.py
+++ b/barcode/__init__.py
@@ -87,9 +87,9 @@ def generate(
     name: str,
     code: str,
     writer=None,
-    output: Union[str, os.PathLike, BinaryIO] = None,
-    writer_options: Dict = None,
-    text: str = None,
+    output: Union[str, os.PathLike, BinaryIO, None] = None,
+    writer_options: Union[Dict, None] = None,
+    text: Union[str, None] = None,
 ):
     """Shortcut to generate a barcode in one line.
 

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -101,6 +101,8 @@ class BaseWriter:
         self.text_line_distance = 1
         self.center_text = True
         self.guard_height_factor = 1.1
+        self.margin_top = 1
+        self.margin_bottom = 1
 
     def calculate_size(self, modules_per_line, number_of_lines):
         """Calculates the size of the barcode in pixel.
@@ -115,7 +117,7 @@ class BaseWriter:
         :rtype: Tuple
         """
         width = 2 * self.quiet_zone + modules_per_line * self.module_width
-        height = 2.0 + self.module_height * number_of_lines
+        height = self.margin_bottom + self.margin_top + self.module_height * number_of_lines
         number_of_text_lines = len(self.text.splitlines())
         if self.font_size and self.text:
             height += (
@@ -204,7 +206,7 @@ class BaseWriter:
         """
         if self._callbacks["initialize"] is not None:
             self._callbacks["initialize"](code)
-        ypos = 1.0
+        ypos = self.margin_top
         base_height = self.module_height
         for cc, line in enumerate(code):
             # Left quiet zone is x startposition

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -428,7 +428,7 @@ else:
             size = [
                 (mm2px(xpos, self.dpi), mm2px(ypos, self.dpi)),
                 (
-                    mm2px(xpos + width, self.dpi),
+                    mm2px(xpos + width, self.dpi) - 1,
                     mm2px(ypos + self.module_height, self.dpi),
                 ),
             ]

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -117,7 +117,9 @@ class BaseWriter:
         :rtype: Tuple
         """
         width = 2 * self.quiet_zone + modules_per_line * self.module_width
-        height = self.margin_bottom + self.margin_top + self.module_height * number_of_lines
+        height = (
+            self.margin_bottom + self.margin_top + self.module_height * number_of_lines
+        )
         number_of_text_lines = len(self.text.splitlines())
         if self.font_size and self.text:
             height += (


### PR DESCRIPTION
Implement PZN8 code generation. Fixes  #167.

* keeping `PZN` for PZN7, implementing `PZN8` for PZN8 
* checksum is commonly part of the PZN* code. Hence, we verify **or** append the checksum based on the length of the supplied PZN7 or PZN8 code.
* explicit error messages concerning code length for both classes respectively
* different checksum calculation for PZN8. see http://www.pruefziffernberechnung.de/P/PZN.shtml

# usage

check code length
```
>>> PZN('12345678')
barcode.errors.NumberOfDigitsError: PZN7 must have 6 digits (excluding checksum) or 7 digits (including checksum), not 8.
>>> PZN8('123456789')
barcode.errors.NumberOfDigitsError: PZN8 must have 7 digits (excluding checksum) or 8 digits (including checksum), not 9.
```

auto-append checksum
```
>>> PZN('123456')
<PZN7('PZN-1234562')>
>>> PZN8('1234567')
<PZN8('PZN-12345678')>
```

verify checksum if supplied
```
>>> PZN('1234568')
barcode.errors.BarcodeError: Checksum (last digit) is not valid for the supplied PZN7 code.
>>> PZN('1234562')
<PZN7('PZN-1234562')>
```

# resources (mostly german)

* checksum details http://www.pruefziffernberechnung.de/P/PZN.shtml
* official specification https://www.ifaffm.de/de/ifa-codingsystem/codierung-pzn-code_39.html



# samples

PZN7: https://barcode.tec-it.com/de/Health_PZN7
<img width="416" alt="pzn7" src="https://user-images.githubusercontent.com/20643301/205035078-0367faef-9aa9-4e5b-aa41-2bd9db27c922.png">

PZN8: https://www.softmatic.com/de/barcode-code-pzn.html
<img width="428" alt="pzn8" src="https://user-images.githubusercontent.com/20643301/205035107-60fc83fc-ebbc-47b6-b961-d633f5aec1c0.png">

