### PR TITLE
fix checksum issue from #196

### DIFF
--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -90,9 +90,9 @@ class EuropeanArticleNumber13(Barcode):
         def sum_(x, y):
             return int(x) + int(y)
 
-        evensum = reduce(sum_, self.ean[-2::-2])
-        oddsum = reduce(sum_, self.ean[-1::-2])
-        return (10 - ((evensum + oddsum * 3) % 10)) % 10
+        evensum = reduce(sum_, self.ean[1:12:2])
+        oddsum = reduce(sum_, self.ean[0:11:2])
+        return (10 - ((oddsum + evensum * 3) % 10)) % 10
 
     def build(self):
         """Builds the barcode pattern from `self.ean`.


### PR DESCRIPTION
As discussed in #196, there is an issue with the generation of checksums for 13 digit EAN's.

```
>>> EAN13("842169142322")
evens_old 221628
evens_new 419432
evens_old_sum 21
evens_new_sum 23
odds_old 234914
odds_new 826122
odds_old_sum 23
odds_new_sum 21
old_return 4
new_return 0
<EuropeanArticleNumber13('8421691423220')>
>>> ean = EAN13("842169142322")
evens_old 221628
evens_new 419432
evens_old_sum 21
evens_new_sum 23
odds_old 234914
odds_new 826122
odds_old_sum 23
odds_new_sum 21
old_return 4
new_return 0
>>> ean.calculate_checksum()
evens_old 234914
evens_new 419432
evens_old_sum 23
evens_new_sum 23
odds_old 0221628
odds_new 826122
odds_old_sum 21
odds_new_sum 21
old_return 4
new_return 0
0
```

As seen in the except above, the PR here fixes this issue.