### PR TITLE
add font_size zero to doc

### DIFF
--- a/docs/writers.rst
+++ b/docs/writers.rst
@@ -32,6 +32,7 @@ be set).
 
 :font_size:
     Font size of the text under the barcode in pt as *integer*.
+    Font size zero suppresses text.
     Defaults to **10**.
 
 :text_distance:


### PR DESCRIPTION
I was going to add the ability to suppress text, but this package already has the functionality.

The special case of font_size 0 should be mentioned in the docs.