### PR TITLE
Update isxn.py to account for ISBN standard changes.

### DIFF
--- a/barcode/isxn.py
+++ b/barcode/isxn.py
@@ -45,7 +45,7 @@ class InternationalStandardBookNumber13(EuropeanArticleNumber13):
         self.isbn13 = isbn
         if isbn[:3] not in ("978", "979"):
             raise WrongCountryCodeError("ISBN must start with 978 or 979.")
-        if isbn[:3] == "979" and isbn[3:5] not in ("10", "11"):
+        if isbn[:3] == "979" and isbn[3:4] not in ("1", "8"):
             raise BarcodeError("ISBN must start with 97910 or 97911.")
         super().__init__(isbn, writer)
 


### PR DESCRIPTION
As discussed here https://www.isbn-international.org/content/changes-united-states-isbn-prefixes the valid ISBN range is being extended to include ISBN-979-8

Should fix #175 