### PR TITLE
upgrade macOS-11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         variant: [ "py", "py-images" ]
         include:
-          - os: macOS-10.15
+          - os: macOS-11
             python: "3.10"
             variant: py-images
           - os: windows-2019


### PR DESCRIPTION
CI failed because macOS-10.15 is deprecated.

See https://github.com/actions/runner-images/issues/5583

Upgrade to macOS-11