### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/netromdk/vermin
+    rev: v1.5.2
+    hooks:
+      - id: vermin
+        args: ['-t=3.8-', '--violations']

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ python-barcode
 There are no external dependencies when generating SVG files.
 Pillow is required for generating images (e.g.: PNGs).
 
-Support Python 3.7 to 3.11.
+Support Python 3.8 to 3.11.
 
 .. image:: example-ean13.png
   :target: https://github.com/WhyNotHugo/python-barcode

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 unreleased
 ~~~~~~~~~~
 
-* **Breaking** Dropped support for Python 3.6.
+* **Breaking** Dropped support for Python 3.6 and 3.7.
 * Added support for Python 3.11.
 
 v0.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ write_to = "barcode/version.py"
 version_scheme = "post-release"
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.ruff]
 select = [
@@ -39,7 +39,7 @@ select = [
     "PLE",
     "RUF",
 ]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.isort]
 force-single-line = true

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py37,py38,py39,py310,py311}{,-images}
+envlist = {py38,py39,py310,py311}{,-images}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Two barcode implementation were actually already broken for 3.7. Rather
than fix them, drop 3.7 entirely, since its extended support is ending
next week anyway.

