### PR TITLE
Allow SVGWriter to avoid having the background element

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -322,7 +322,7 @@ class SVGWriter(BaseWriter):
         attributes = {"id": "barcode_group"}
         _set_attributes(group, **attributes)
         self._group = self._root.appendChild(group)
-        if self.background and self.background != (255, 255, 255, 0):
+        if self.background is not None:
             background = self._document.createElement("rect")
             attributes = {
                 "width": "100%",

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -322,14 +322,15 @@ class SVGWriter(BaseWriter):
         attributes = {"id": "barcode_group"}
         _set_attributes(group, **attributes)
         self._group = self._root.appendChild(group)
-        background = self._document.createElement("rect")
-        attributes = {
-            "width": "100%",
-            "height": "100%",
-            "style": f"fill:{self.background}",
-        }
-        _set_attributes(background, **attributes)
-        self._group.appendChild(background)
+        if self.background and self.background != (255, 255, 255, 0):
+            background = self._document.createElement("rect")
+            attributes = {
+                "width": "100%",
+                "height": "100%",
+                "style": f"fill:{self.background}",
+            }
+            _set_attributes(background, **attributes)
+            self._group.appendChild(background)
 
     def _create_module(self, xpos, ypos, width, color):
         # Background rect has been provided already, so skipping "spaces"


### PR DESCRIPTION
With this PR I modified SVGWriter to be able to avoid having the background element on SVG images

If you set the "background" to None or (255,255,255,0) (i.e. transparent) in the writer_options parameter when calling render then the background will not be written in the SVG (instead of having a rectangle).

This is because transparent background does not seem to work in the current library (it is black)