### PR TITLE
Fix size and text distance

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -127,7 +127,7 @@ class BaseWriter:
         number_of_text_lines = len(self.text.splitlines())
         if self.font_size and self.text:
             height += (
-                pt2mm(self.font_size) / 2 * number_of_text_lines + self.text_distance
+                pt2mm(self.font_size) * number_of_text_lines + self.text_distance
             )
             height += self.text_line_distance * (number_of_text_lines - 1)
         return width, height

--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -284,7 +284,7 @@ class BaseWriter:
                 # Split the ean into its blocks
                 self.text = self.text.split(" ")
 
-                ypos += pt2mm(self.font_size)
+                ypos += pt2mm(self.font_size) + self.text_distance
 
                 blocks = self.text
                 for text_, xpos in zip(blocks, text["xpos"]):


### PR DESCRIPTION
I spotted two problems while writing a program:

1) text_distance is not applied if guardbar is on
2) the height calculation is not correct (it only accounts for half of the font width), and this caused the images being too short

I fixed the two issues in this PR