### PR TITLE
Fixed erroneous calculation in calculate_checksum

### DIFF
--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -84,8 +84,9 @@ class EuropeanArticleNumber13(Barcode):
 
         def sum_(x, y):
             return int(x) + int(y)
-        ean_without_checksum = self.ean[:self.digits]
-        
+
+        ean_without_checksum = self.ean[: self.digits]
+
         evensum = reduce(sum_, ean_without_checksum[-2::-2])
         oddsum = reduce(sum_, ean_without_checksum[-1::-2])
         return (10 - ((evensum + oddsum * 3) % 10)) % 10

--- a/barcode/ean.py
+++ b/barcode/ean.py
@@ -84,9 +84,10 @@ class EuropeanArticleNumber13(Barcode):
 
         def sum_(x, y):
             return int(x) + int(y)
-
-        evensum = reduce(sum_, self.ean[-2::-2])
-        oddsum = reduce(sum_, self.ean[-1::-2])
+        ean_without_checksum = self.ean[:self.digits]
+        
+        evensum = reduce(sum_, ean_without_checksum[-2::-2])
+        oddsum = reduce(sum_, ean_without_checksum[-1::-2])
         return (10 - ((evensum + oddsum * 3) % 10)) % 10
 
     def build(self):


### PR DESCRIPTION
The EAN checksum calculation is correct only if the `self.ean` variable does not have the checksum value already present. This may not be true in some cases (e.g. someone trying to compare an already present checksum with the library-generated one)