### PR TITLE
Minor renovations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-22.04
     name: Publish package on PyPI
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - run: pip install build setuptools wheel build setuptools_scm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,17 +7,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
+        os: [ ubuntu-22.04 ]
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         variant: [ "py", "py-images" ]
         include:
-          - os: macOS-11
-            python: "3.10"
+          - os: macOS-12
+            python: "3.12"
             variant: py-images
-          - os: windows-2019
-            python: "3.10"
+          - os: windows-2022
+            python: "3.12"
             variant: py-images
-          - os: windows-2019
+          - os: windows-2022
     name: python${{ matrix.python }} on ${{ matrix.os }} ${{ matrix.variant }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,14 @@ jobs:
           - os: windows-2019
     name: python${{ matrix.python }} on ${{ matrix.os }} ${{ matrix.variant }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            setup.py
       - name: Install test dependency
         run: pip install tox
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/psf/black
-    rev: "23.7.0"
+    rev: "23.11.0"
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.5.1'
+    rev: 'v1.7.1'
     hooks:
     -   id: mypy
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.0.287'
+    rev: 'v0.1.6'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/netromdk/vermin
-    rev: v1.5.2
+    rev: v1.6.0
     hooks:
       - id: vermin
         args: ['-t=3.8-', '--violations']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,6 @@ repos:
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
       - id: debug-statements
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.7.1'
     hooks:
@@ -19,6 +15,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/netromdk/vermin
     rev: v1.6.0
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ python-barcode
 There are no external dependencies when generating SVG files.
 Pillow is required for generating images (e.g.: PNGs).
 
-Support Python 3.8 to 3.11.
+Support Python 3.8 to 3.12.
 
 .. image:: example-ean13.png
   :target: https://github.com/WhyNotHugo/python-barcode

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 python-barcode
 ==============
 
-.. image:: https://action-badges.now.sh/WhyNotHugo/python-barcode
+.. image:: https://github.com/WhyNotHugo/python-barcode/actions/workflows/tests.yml/badge.svg
   :target: https://github.com/WhyNotHugo/python-barcode/actions
   :alt: CI status
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 write_to = "barcode/version.py"
 version_scheme = "post-release"
 
-[tool.black]
-target-version = ['py38']
-
 [tool.ruff]
 select = [
     "F",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Multimedia :: Graphics",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],


### PR DESCRIPTION
* pre-commit tool upgrades
* GitHub Actions component upgrades
* CI OS and Python version updates
* Mark official support for Python 3.12 too
* Fix CI status badge to use native GitHub Actions SVG
* [ruff-format for formatting](https://astral.sh/blog/the-ruff-formatter) (identical output to black for this repo 🎉)