### PR TITLE
Fix no_checksum for EAN13

### DIFF
--- a/tests/test_ean.py
+++ b/tests/test_ean.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import sys
+
+import pytest
+
 from barcode.ean import EAN13
 
 
@@ -19,3 +23,31 @@ def test_ean_checksum_supplied_and_generated() -> None:
     ean = EAN13("8421671433225")  # input has 13 digits
     assert ean.calculate_checksum() == 5
     assert ean.ean == "8421671433225"
+
+
+def test_ean_checksum_supplied_and_matching() -> None:
+    ean = EAN13("8421671433225", no_checksum=True)  # input has 13 digits
+    assert ean.calculate_checksum() == 5
+    assert ean.ean == "8421671433225"
+
+
+def test_ean_checksum_supplied_and_different() -> None:
+    ean = EAN13("8421671433229", no_checksum=True)  # input has 13 digits
+    assert ean.calculate_checksum() == 5
+    assert ean.ean == "8421671433229"
+
+
+def test_ean_checksum_generated_placeholder() -> None:
+    ean = EAN13("977114487500X")  # input has 13 digits
+    assert ean.calculate_checksum() == 7
+    assert ean.ean == "9771144875007"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no /dev/null")
+def test_ean_checksum_supplied_placeholder() -> None:
+    ean = EAN13("977114487500X", no_checksum=True)  # input has 13 digits
+    assert ean.calculate_checksum() == 7
+    assert ean.ean == "9771144875000"
+
+    with open("/dev/null", "wb") as f:
+        ean.write(f)


### PR DESCRIPTION
The `ean` variable was shadowed early, so a custom 13th digit was lost when ignoring checksums.

Fixes: https://github.com/WhyNotHugo/python-barcode/issues/43