### PR TITLE
Cleanup of barcode.codex._convert

### DIFF
--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -210,7 +210,9 @@ class Code128(Barcode):
                 codes = self._new_charset("B")
             elif char in code128.A:
                 codes = self._new_charset("A")
+            assert self._charset != "C"
             if len(self._digit_buffer) == 1:
+                # Flush the remaining single digit from the buffer
                 codes.append(self._convert(self._digit_buffer[0]))
                 self._digit_buffer = ""
         elif self._charset == "B":
@@ -282,7 +284,8 @@ class Code128(Barcode):
             code_num = self._convert_or_buffer(char)
             if code_num is not None:
                 encoded.append(code_num)
-        # Finally look in the buffer
+        # If we finish in charset C with a single digit remaining in the buffer,
+        # switch to charset B and flush out the buffer.
         if len(self._digit_buffer) == 1:
             encoded.extend(self._new_charset("B"))
             encoded.append(self._convert(self._digit_buffer[0]))

--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -254,14 +254,14 @@ class Code128(Barcode):
                 return code128.C[char]
             if char.isdigit():
                 self._buffer += char
-                if len(self._buffer) == 2:
-                    value = int(self._buffer)
-                    self._buffer = ""
-                    return value
-                return None
-        raise RuntimeError(
-            f"Character {char} could not be converted in charset {self._charset}."
-        )
+                if len(self._buffer) == 1:
+                    # Wait for the second digit to group in pairs
+                    return None
+                assert len(self._buffer) == 2
+                value = int(self._buffer)
+                self._buffer = ""
+                return value
+        raise RuntimeError(f"Character {char} could not be converted in charset C.")
 
     def _try_to_optimize(self, encoded: list[int]) -> list[int]:
         if encoded[1] in code128.TO:

--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -66,12 +66,14 @@ class Code39(Barcode):
         """:returns: The full code as it will be encoded."""
         return self.code
 
-    def calculate_checksum(self):
+    def calculate_checksum(self) -> str:
         check = sum(code39.MAP[x][0] for x in self.code) % 43
         for k, v in code39.MAP.items():
             if check == v[0]:
                 return k
-        return None
+        raise RuntimeError(
+            "All possible values for the checksum should have been included in the map."
+        )
 
     def build(self) -> list[str]:
         chars = [code39.EDGE]

--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -249,18 +249,17 @@ class Code128(Barcode):
         """
         if self._charset != "C":
             return self._convert(char)
-        else:
-            if char in code128.C:
-                return code128.C[char]
-            if char.isdigit():
-                self._buffer += char
-                if len(self._buffer) == 1:
-                    # Wait for the second digit to group in pairs
-                    return None
-                assert len(self._buffer) == 2
-                value = int(self._buffer)
-                self._buffer = ""
-                return value
+        if char in code128.C:
+            return code128.C[char]
+        if char.isdigit():
+            self._buffer += char
+            if len(self._buffer) == 1:
+                # Wait for the second digit to group in pairs
+                return None
+            assert len(self._buffer) == 2
+            value = int(self._buffer)
+            self._buffer = ""
+            return value
         raise RuntimeError(f"Character {char} could not be converted in charset C.")
 
     def _try_to_optimize(self, encoded: list[int]) -> list[int]:


### PR DESCRIPTION
Most invocations of `_convert` are guaranteed to not handle digits in charset C. Handling extra digits in charset C introduces extra complexity due to grouping of pairs of digits, which is handled by `_buffer`. (I rename `_buffer` to `_digit_buffer` for clarity.)

In order to isolate the complexity and ease type hinting, I restrict `_convert` to return only `int` and raise an informative exception whenever the buffer is triggered. Correspondingly I introduce a function `_convert_or_buffer` returning `int | None` to handle the full case when `_digit_buffer` might be used.

There is just one single place (`_build`) where `_convert_or_buffer` is necessary rather than `_convert`.

Reasons why `_convert` is safe to use in all other invocations:
* In `_new_charset` it's used to switch charset, so it won't be used on a digit.
* In `_maybe_switch_charset` and `_build` it's used to flush the buffer immediately after switching to either charset A or B, so the charset cannot be C.
* In `_convert_or_buffer` I explicitly check before invoking that the charset isn't C.

This makes it clear why only the invocation in `_build` needs to handle the `None` return type. (IMO it's pretty tricky to deduce this if you're not already familiar with the implementation.)