### PR TITLE
fix: migrate project.license to SPDX expression (#260)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Unreleased
+~~~~~~~~~~
+* Migrate ``project.license`` to an SPDX expression and drop the deprecated
+  ``License ::`` trove classifier, silencing the ``setuptools >=77``
+  deprecation warning. (#260)
+
 v0.16.2
 ~~~~~~~
 * Add support for Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=77", "wheel", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,7 @@ name = "python-barcode"
 description = "Create standard barcodes with Python. No external modules needed. (optional Pillow support included)."
 readme = "README.rst"
 requires-python = ">=3.9"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
   { name = "Hugo Osvaldo Barrera et al", email = "hugo@whynothugo.nl" }
 ]
@@ -15,7 +15,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Problem
Fixes #260. Building with setuptools >=77 emits two deprecation warnings: `project.license` as a TOML table, and the `License :: OSI Approved :: MIT License` trove classifier. Both point at the PEP 639 migration. Confirmed on main HEAD 1d872d3.

## Root cause
`pyproject.toml` uses the PEP 621 table form `license = { text = "MIT" }` and also lists the `License ::` classifier. setuptools 77.0.0 (PEP 639) deprecates both in favour of an SPDX string expression.

## Fix
- `license = { text = "MIT" }` -> `license = "MIT"` (SPDX expression)
- drop the `License :: OSI Approved :: MIT License` classifier
- bump build-system `setuptools>=61` -> `>=77` (the SPDX string form needs >=77; the warning itself notes "available on setuptools>=77.0.0")

Metadata only; no runtime change.

## How to test
Before:
```
$ python -m build
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated ...
SetuptoolsDeprecationWarning: License classifiers are deprecated.
  License :: OSI Approved :: MIT License
```
After:
```
$ python -m build
adding license file 'LICENCE'      # no license/classifier deprecation warnings
```
Full suite: 47 passed.

## Backward compatibility
Build floor moves to setuptools >=77 (compatible with `requires-python >= 3.9`; setuptools 77 supports 3.9+). Runtime unchanged. pip build isolation already resolves >=77.

---
Assisted-by: Claude (code generation, reviewed and tested locally)
