### PR TITLE
fix: ISSN checksum returns 11 instead of 0 when weighted sum is divisible by 11

### DIFF
--- a/barcode/isxn.py
+++ b/barcode/isxn.py
@@ -113,7 +113,7 @@ class InternationalStandardSerialNumber(EuropeanArticleNumber13):
             11
             - sum(x * int(y) for x, y in enumerate(reversed(self.issn[:7]), start=2))
             % 11
-        )
+        ) % 11
         if tmp == 10:
             return "X"
 

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -46,3 +46,16 @@ def test_isbn13_checksum() -> None:
 def test_gs1_128_checksum() -> None:
     gs1_128 = get_barcode("gs1_128", "00376401856400470087")
     assert gs1_128.get_fullcode() == "00376401856400470087"
+
+
+def test_issn_checksum_zero() -> None:
+    # When the weighted sum is divisible by 11, the checksum should be 0,
+    # not 11. Regression test for issue #238.
+    issn = get_barcode("issn", "6727893")
+    assert issn.issn == "67278930"  # type: ignore[attr-defined]
+
+
+def test_issn_checksum_x() -> None:
+    # When (11 - weighted_sum % 11) % 11 == 10, checksum should be "X".
+    issn = get_barcode("issn", "0000006")
+    assert issn.issn == "0000006X"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fixes #238.

The `_calculate_checksum` method in `InternationalStandardSerialNumber` was missing a trailing `% 11`. When the weighted digit sum is exactly divisible by 11, the formula computes `11 - 0 = 11` — an invalid two-digit value — instead of `(11 - 0) % 11 = 0`.

**Before:**
```python
tmp = (
    11
    - sum(x * int(y) for x, y in enumerate(reversed(self.issn[:7]), start=2))
    % 11
)
```

**After:**
```python
tmp = (
    11
    - sum(x * int(y) for x, y in enumerate(reversed(self.issn[:7]), start=2))
    % 11
) % 11
```

Minimal reproduction:
```python
from barcode import ISSN
print(ISSN("6727893").issn)  # was "672789311", now correctly "67278930"
```

Two regression tests added to `tests/test_checksums.py`: one for the zero-checksum case and one confirming the `X` checksum case still works.

This pull request was prepared with the assistance of AI, under my direction and review.