### PR TITLE
Fix Code128 build() producing different output on repeated calls

### DIFF
--- a/barcode/codex.py
+++ b/barcode/codex.py
@@ -278,6 +278,10 @@ class Code128(Barcode):
         return sum(cs) % 103
 
     def _build(self) -> list[int]:
+        # Reset the state that gets mutated while building so that repeated
+        # calls on the same instance are deterministic (see #143).
+        self._charset = "C"
+        self._digit_buffer = ""
         encoded: list[int] = [code128.START_CODES[self._charset]]
         for i, char in enumerate(self.code):
             encoded.extend(self._maybe_switch_charset(i))

--- a/tests/test_code128.py
+++ b/tests/test_code128.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from barcode.codex import Code128
+
+
+def test_build_is_stable_across_repeated_calls() -> None:
+    """Calling build() repeatedly on the same instance must be deterministic.
+
+    Regression test for #143: ``_build`` mutated ``_charset`` and
+    ``_digit_buffer`` without resetting them, so a second call started from
+    stale state and produced a different bit string.
+    """
+    code = Code128("12A")
+    first = code.build()
+    assert code.build() == first
+    assert code.build() == first
+
+
+def test_encoded_is_stable_across_repeated_calls() -> None:
+    """The ``encoded`` property must also be deterministic across calls."""
+    code = Code128("12A")
+    first = code.encoded
+    assert code.encoded == first
+    assert code.encoded == first
+
+
+def test_reused_instance_matches_fresh_instance() -> None:
+    """A reused instance must encode identically to a freshly built one."""
+    reused = Code128("123ABC456")
+    reused.build()  # dirties the internal charset/buffer state
+    assert reused.build() == Code128("123ABC456").build()


### PR DESCRIPTION
Fixes #143

## Root cause

`Code128._build` mutates `self._charset` and `self._digit_buffer` while it walks the code (switching charsets via `_new_charset`, buffering digit pairs in charset C). Both attributes are initialised only once, in `__init__`. When a build ends in charset A/B — or with a digit still buffered — those attributes are left in a "dirty" state. The next call to `build()` / `encoded` starts from that stale state instead of the intended `_charset = "C"` / empty buffer, so it emits a different (and incorrect) bit string.

## Reproduction

```python
from barcode import Code128

inst = Code128("12A")
for _ in range(3):
    print(inst.build()[0])
```

Observed (before the fix) — the first call is correct, later calls diverge:

```
11010011100101100111001011110111010100011000100100011001100011101011
11010010000100111001101100111001010100011000110001011101100011101011
11010010000100111001101100111001010100011000110001011101100011101011
```

The divergence is the start code: the first build begins in charset C (`START_C` = 105); after it the instance is left in charset B, so later builds begin with `START_B` = 104. A freshly constructed `Code128("12A")` always reproduces the first (correct) line, confirming the later output is the buggy one.

After the fix every call returns the same, correct value:

```
11010011100101100111001011110111010100011000100100011001100011101011
11010011100101100111001011110111010100011000100100011001100011101011
11010011100101100111001011110111010100011000100100011001100011101011
```

The original report's all-digit example (`Code128("1170773")`) never left charset C, so it happened to be stable on current `main`; inputs that switch charset (e.g. `"12A"`, `"123ABC456"`) expose the bug.

## Fix

Reset `self._charset = "C"` and `self._digit_buffer = ""` at the start of `_build()`, so each build begins from the same initial state regardless of what the previous one left behind. This is the smallest localized change and touches only the entry of `_build`.

## Tests

Added `tests/test_code128.py` with three regression tests asserting that repeated `build()` / `encoded` calls on one instance are deterministic and that a reused instance matches a freshly constructed one. These tests fail on unmodified `main` and pass with the fix. The full existing suite (52 tests, including the GS1-128 charset-C build tests) continues to pass, and `ruff check` / `ruff format --check` are clean.

Disclosure: prepared with AI assistance; reviewed and verified locally.
