### PR TITLE
fix: stop ISBN-10/ISSN digits from truncating EAN-13 payload

### DIFF
--- a/barcode/isxn.py
+++ b/barcode/isxn.py
@@ -66,11 +66,11 @@ class InternationalStandardBookNumber10(InternationalStandardBookNumber13):
 
     name = "ISBN-10"
 
-    digits = 9
+    isbn_digits = 9
 
     def __init__(self, isbn, writer=None) -> None:
         isbn = isbn.replace("-", "")
-        isbn = isbn[: self.digits]
+        isbn = isbn[: self.isbn_digits]
         super().__init__("978" + isbn, writer)
         self.isbn10 = isbn
         self.isbn10 = f"{isbn}{self._calculate_checksum()}"
@@ -99,11 +99,11 @@ class InternationalStandardSerialNumber(EuropeanArticleNumber13):
 
     name = "ISSN"
 
-    digits = 7
+    issn_digits = 7
 
     def __init__(self, issn, writer=None) -> None:
         issn = issn.replace("-", "")
-        issn = issn[: self.digits]
+        issn = issn[: self.issn_digits]
         self.issn = issn
         self.issn = f"{issn}{self._calculate_checksum()}"
         super().__init__(self.make_ean(), writer)

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -36,6 +36,9 @@ def test_ean14_checksum() -> None:
 def test_isbn10_checksum() -> None:
     isbn = get_barcode("isbn10", "376926085")
     assert isbn.isbn10 == "3769260856"  # type: ignore[attr-defined]
+    # ISBN-10 is rendered as EAN-13 with a 978 prefix; digits=9 must not
+    # poison EuropeanArticleNumber13 slicing.
+    assert isbn.get_fullcode() == "9783769260854"
 
 
 def test_isbn13_checksum() -> None:
@@ -53,6 +56,7 @@ def test_issn_checksum_zero() -> None:
     # not 11. Regression test for issue #238.
     issn = get_barcode("issn", "6727893")
     assert issn.issn == "67278930"  # type: ignore[attr-defined]
+    assert issn.get_fullcode() == "9776727893003"
 
 
 def test_issn_checksum_x() -> None:

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -36,8 +36,7 @@ def test_ean14_checksum() -> None:
 def test_isbn10_checksum() -> None:
     isbn = get_barcode("isbn10", "376926085")
     assert isbn.isbn10 == "3769260856"  # type: ignore[attr-defined]
-    # ISBN-10 is rendered as EAN-13 with a 978 prefix; digits=9 must not
-    # poison EuropeanArticleNumber13 slicing.
+    # ISBN-10 renders as EAN-13; isbn_digits must not shadow EAN digits.
     assert isbn.get_fullcode() == "9783769260854"
 
 


### PR DESCRIPTION
barcode.isxn.ISBN10/ISSN.__init__ hits DataLoss when subclass digits overrides EAN13.digits truncating get_fullcode. This PR fixes the regression with a focused test covering the case.